### PR TITLE
Relax dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'nltk',
-        'transformers==4.3.3',
-        'datasets==1.5.0',
+        'transformers>=4.3',
+        'datasets>=1.5',
         'cleantext',
-        'bert_score==0.3.9',
+        'bert_score>=0.3',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR unpins dependencies in `setup.py` which should make it easier to install `ctc_score` in a project that already uses some of those dependencies. 

I have tested this with `demo.py` and latest dependencies. The scores are equivalent to the one achieved on master.

```
$ python demo.py
0.9349942701713493
16.073128163814545
0.46437557367322685
```

```
$ pip freeze
aiohttp==3.8.1
aiosignal==1.2.0
async-timeout==4.0.1
attrs==21.2.0
bert-score==0.3.10
certifi==2021.10.8
charset-normalizer==2.0.9
cleantext==1.1.3
click==8.0.3
-e git+ssh://git@github.com/jantrienes/ctc-gen-eval.git@67613c76976d07af5af1790492a7cd023659667b#egg=ctc_score
cycler==0.11.0
datasets==1.16.1
dill==0.3.4
filelock==3.4.0
fonttools==4.28.3
frozenlist==1.2.0
fsspec==2021.11.1
huggingface-hub==0.2.1
idna==3.3
joblib==1.1.0
kiwisolver==1.3.2
matplotlib==3.5.0
multidict==5.2.0
multiprocess==0.70.12.2
nltk==3.6.5
numpy==1.21.4
packaging==21.3
pandas==1.3.4
Pillow==8.4.0
pyarrow==6.0.1
pyparsing==3.0.6
python-dateutil==2.8.2
pytz==2021.3
PyYAML==6.0
regex==2021.11.10
requests==2.26.0
sacremoses==0.0.46
setuptools-scm==6.3.2
six==1.16.0
tokenizers==0.10.3
tomli==1.2.2
torch==1.10.0
tqdm==4.62.3
transformers==4.12.5
typing-extensions @ file:///tmp/build/80754af9/typing_extensions_1631814937681/work
urllib3==1.26.7
xxhash==2.0.2
yarl==1.7.2
```